### PR TITLE
fix most shellcheck issues

### DIFF
--- a/backupVMs.sh
+++ b/backupVMs.sh
@@ -5,7 +5,7 @@ function quit
 echo "$*" ; exit
 }
 
-function usage 
+function usage
 {
   echo "Usage: $0 -d [-c] -p -l -g -v -s [-x] [-z] [-h]"
   echo "-d Space-seperated list of the virtuel disks e.g. /vm/HDD1.img /vm/HDD2.img"
@@ -24,8 +24,8 @@ function usage
 function removeLv
 {
 echo "remove Snapshot"
-if ! lvremove -f /dev/${nameOfVolumeGroup}/${nameOfSnapshotVolume}; then
- quit "Error: faild to remove the logical volume snapshot \n(a maual correction is necessary !)" 
+if ! lvremove -f /dev/"${nameOfVolumeGroup}"/"${nameOfSnapshotVolume}"; then
+ quit "Error: faild to remove the logical volume snapshot \n(a maual correction is necessary !)"
 fi
 }
 
@@ -45,27 +45,27 @@ do
   esac
 done
 
-if test -z "${toBackupVmHdds}" ; then 
+if test -z "${toBackupVmHdds}" ; then
   quit "Error(-d): no virtual disk selected"
 fi
 
-if test ! -d ${pathOfBackupDir} ; then 
+if test ! -d "${pathOfBackupDir}" ; then
   quit "Error(-p): directory ${pathOfBackupDir} does not exsist"
 fi
 
-if test -z ${pathOfSnapshotDir} ; then
+if test -z "${pathOfSnapshotDir}" ; then
   quit "Error(-l): you must specify a directory, to mount the logical volume snapshot."
 fi
 
-if test ! -e /dev/${nameOfVolumeGroup}/${nameOfLogicalVolume} ; then 
+if test ! -e /dev/"${nameOfVolumeGroup}"/"${nameOfLogicalVolume}" ; then
   quit "Error(-g/-v): volume name (${nameOfLogicalVolume}) or/and volume group (${nameOfVolumeGroup}) does not exsist"
 fi
 
-if test -z "${sizeOfSnapshot}" ; then 
+if test -z "${sizeOfSnapshot}" ; then
   quit "Error(-s): you must specify a size for the logical volume snapshot"
 fi
 
-if test -z "${encKey}" ; then 
+if test -z "${encKey}" ; then
   enableEncryption="false"
   else
   enableEncryption="true"
@@ -75,55 +75,55 @@ if test -z "${compressProgram}" ; then
   compressProgram="gzip"
 fi
 
-backupVolumeNameSuffix="_Snapshot" 
-dateAndTime=`date +"%d.%m.%y-%H%M"` # will be added to the backups name
-mountPointLogicalVolume=`mount | grep ${nameOfLogicalVolume} | grep ${nameOfVolumeGroup} | awk 'BEGIN {FS=" "} ; {print $3}' | sed "s/\//\\\\\\\\\//g"`
-nameOfSnapshotVolume=${nameOfLogicalVolume}${backupVolumeNameSuffix} 
-listOfHdds=`echo $toBackupVmHdds | sed "s/ /_/g" | sed "s/\//:/g" | awk 'BEGIN {FS=":"} ; {print $NF}'` # replace space by '_' and replace '/' by ':'
-comment=`echo $backupComment | sed "s/ /_/g"` #replace spaces in the comment by '_' 
+backupVolumeNameSuffix="_Snapshot"
+dateAndTime=$(date +"%d.%m.%y-%H%M") # will be added to the backups name
+mountPointLogicalVolume=$(mount | grep "${nameOfLogicalVolume}" | grep "${nameOfVolumeGroup}" | awk 'BEGIN {FS=" "} ; {print $3}' | sed "s/\//\\\\\\\\\//g")
+nameOfSnapshotVolume="${nameOfLogicalVolume}""${backupVolumeNameSuffix}"
+listOfHdds=$(echo "$toBackupVmHdds" | sed "s/ /_/g" | sed "s/\//:/g" | awk 'BEGIN {FS=":"} ; {print $NF}') # replace space by '_' and replace '/' by ':'
+comment=$(echo "$backupComment" | sed "s/ /_/g") #replace spaces in the comment by '_'
 nameOfBackup=${dateAndTime}-${comment}
-pathOfSnapshotDirTmp=`echo $pathOfSnapshotDir | sed "s/\//\\\\\\\\\//g"` # replace '/' by '\/' 
-toBackupVmHdds=`echo $toBackupVmHdds | sed "s/${mountPointLogicalVolume}/${pathOfSnapshotDirTmp}/g"` # replace the original path through the snapshots one 
+pathOfSnapshotDirTmp=$(echo "$pathOfSnapshotDir" | sed "s/\//\\\\\\\\\//g") # replace '/' by '\/'
+toBackupVmHdds=$(echo "$toBackupVmHdds" | sed "s/${mountPointLogicalVolume}/${pathOfSnapshotDirTmp}/g") # replace the original path through the snapshots one
 
 # start of backup process
 
 echo "enable kernelmodul dm-snapshot"
 if ! modprobe dm-snapshot; then
- quit "Error: when activating kernel module: dm-snapshot" 
+ quit "Error: when activating kernel module: dm-snapshot"
 fi
 
 echo "create $nameOfSnapshotVolume Snapshot"
-if ! lvcreate --size ${sizeOfSnapshot} --snapshot --name ${nameOfSnapshotVolume} /dev/${nameOfVolumeGroup}/${nameOfLogicalVolume} ; then
- quit "Error: when creating the logical volume snapshot" 
+if ! lvcreate --size "${sizeOfSnapshot}" --snapshot --name "${nameOfSnapshotVolume}" /dev/"${nameOfVolumeGroup}"/"${nameOfLogicalVolume}" ; then
+ quit "Error: when creating the logical volume snapshot"
 fi
 
 echo "create directory ${pathOfSnapshotDir}, if it does not exist"
-if ! mkdir -p ${pathOfSnapshotDir} ; then
+if ! mkdir -p "${pathOfSnapshotDir}" ; then
   removeLv ; quit "Error: could not create directory ${pathOfSnapshotDir}"
 fi
 
 echo "mount Snapshot (read only)"
-if ! mount --read-only  /dev/${nameOfVolumeGroup}/${nameOfSnapshotVolume} ${pathOfSnapshotDir} ; then
- removeLv ; quit "Error: could not mount the snapshot" 
+if ! mount --read-only  /dev/"${nameOfVolumeGroup}"/"${nameOfSnapshotVolume}" "${pathOfSnapshotDir}" ; then
+ removeLv ; quit "Error: could not mount the snapshot"
 fi
 
 echo "backup the virtual hard disks"
 if test "${enableEncryption}" == "true"
   then
     echo "encryption in on"
-    tar --create --use-compress-program=${compressProgram} --verbose -f - ${toBackupVmHdds} | openssl enc -e -aes-256-cbc -salt -pass pass:${encKey} -out ${pathOfBackupDir}/${nameOfBackup}.tar.aes256
+    tar --create --use-compress-program=${compressProgram} --verbose -f - "${toBackupVmHdds}" | openssl enc -e -aes-256-cbc -salt -pass "pass:${encKey}" -out "${pathOfBackupDir}"/"${nameOfBackup}".tar.aes256
   else
     echo "encryption is off"
-    tar --create --use-compress-program=${compressProgram} --verbose -f ${pathOfBackupDir}/${nameOfBackup}.tar ${toBackupVmHdds}
+    tar --create --use-compress-program=${compressProgram} --verbose -f "${pathOfBackupDir}"/"${nameOfBackup}".tar "${toBackupVmHdds}"
 fi
 
 echo "umount ${pathOfSnapshotDir}"
-if ! umount ${pathOfSnapshotDir}; then
- removeLv ; quit "Error: when umount the virtual volume \n(a maual correction is necessary !)" 
+if ! umount "${pathOfSnapshotDir}"; then
+ removeLv ; quit "Error: when umount the virtual volume \n(a manual correction is necessary !)"
 fi
 
-echo "entferne ${pathOfSnapshotDir}"
-rmdir ${pathOfSnapshotDir}
+echo "remove ${pathOfSnapshotDir}"
+rmdir "${pathOfSnapshotDir}"
 
 # remove logical volume snapshot
 removeLv

--- a/recoverVMs.sh
+++ b/recoverVMs.sh
@@ -5,8 +5,8 @@ function quit
   echo "$*" ; exit
 }
 
-function usage 
-{ 
+function usage
+{
   echo "Usage $0 -i -n -t -r [-x] [-z] [-h]"
   echo "-i virtual disk which should be restored"
   echo "-n name of the virtual machine"
@@ -31,26 +31,26 @@ do
   esac
 done
 
-if test ! -f ${vmHddFile} ; then 
+if test ! -f "${vmHddFile}" ; then
   quit "Error(-i): the file ${vmHddFile}  does not exsist"
 fi
 
-stateOfVm=`virsh domstate $nameOfVm`
-if test "${stateOfVm}" == "shut off" ; then 
+stateOfVm=$(virsh domstate "$nameOfVm")
+if test "${stateOfVm}" == "shut off" ; then
   echo "VM ${nameOfVm} is shut off"
 else
-  quit "Error(-n): The VM ${nameOfCm} is ${stateOfVm}, but they must be shut off"
+  quit "Error(-n): The VM ${nameOfVm} is ${stateOfVm}, but they must be shut off"
 fi
 
-if test -z ${backupHddForRecover} ; then 
+if test -z "${backupHddForRecover}" ; then
   quit "Error(-r): you must specify a file from the tar backup archive"
 fi
-    
-if test ! -f ${backupTar} ; then 
-  quit "Error(-t): the file ${backupTar} does not exsist"
-fi  
 
-if test -z "${encKey}" ; then 
+if test ! -f "${backupTar}" ; then
+  quit "Error(-t): the file ${backupTar} does not exsist"
+fi
+
+if test -z "${encKey}" ; then
   enableEncryption="false"
   else
   enableEncryption="true"
@@ -66,8 +66,9 @@ echo "$enableEncryption"
 if test "${enableEncryption}" == "true"
   then
   echo "encryption is on"
-  openssl enc -d -aes-256-cbc -salt -pass pass:${encKey} -in ${backupTar} | tar -x -v --use-compress-program=${compressProgram} -f - ${backupHddForRecover} -O | dd of=${vmHddFile}
+  openssl enc -d -aes-256-cbc -salt -pass "pass:${encKey}" -in "${backupTar}" | tar -x -v --use-compress-program="${compressProgram}" -f - "${backupHddForRecover}" -O | dd of="${vmHddFile}"
   else
   echo "encryption is off"
-  tar -x -v --use-compress-program=${compressProgram} -f ${backupTar} ${backupHddForRecover} -O | dd of=${vmHddFile}
+  tar -x -v --use-compress-program="${compressProgram}" -f "${backupTar}" "${backupHddForRecover}" -O | dd of="${vmHddFile}"
 fi
+


### PR DESCRIPTION
Fixes most [ShellCheck](http://www.shellcheck.net/)([Github repository](https://github.com/koalaman/shellcheck)) warnings, removes all trailing whitespaces, fixes some minor typos

---

Informal german comment:
Hi Volker, 
nach diesem Pull Request sollte man an praktisch in allen Namen auch Leerzeichen verwenden können.
Der Rest ist Kosmetik - außer du willst das auf steinalten Systemen einsetzen, bei denen `$(<command>)` nicht geht.
Drei Punkte bemängelt ShellCheck noch bei `backupVMs.sh`. Bei denen bin ich mir nicht sicher. Soll ich die auch noch mit rein nehmen?
Könntest du vielleicht noch irgendwo irgendwie beschreiben wie man ein System einrichtet um die Scripte zu testen(Sorry, bin zu wenig Admin als dass das für mich klar wäre)?
Viele Grüße,
Jonas
